### PR TITLE
remove unnecessary COPY_DST on the input buffer

### DIFF
--- a/src/repeatable.rs
+++ b/src/repeatable.rs
@@ -102,7 +102,6 @@ impl Runner {
                 label: None,
                 contents: input_bytes,
                 usage: wgpu::BufferUsages::STORAGE
-                    | wgpu::BufferUsages::COPY_DST
                     | wgpu::BufferUsages::COPY_SRC,
             });
         let output_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {


### PR DESCRIPTION
The input buffer is not a dst of a copyBufToCopyBuf, copyTexToBuff, nor writeBuff. So this buffer usage doesn't do anything.

https://www.w3.org/TR/webgpu/#dom-gpubufferusage-copy_dst